### PR TITLE
Fixed PreProcess modifying non LPC assets

### DIFF
--- a/Assets/Editor/bitcula/LpcSpriteProcessor.cs
+++ b/Assets/Editor/bitcula/LpcSpriteProcessor.cs
@@ -52,6 +52,10 @@ public class LpcSpriteProcessor : AssetPostprocessor {
 
 	void OnPreprocessTexture()
 	{
+		Texture2D texture = AssetDatabase.LoadAssetAtPath(assetPath, typeof(Texture2D)) as Texture2D);
+		if (!IsLpcSpriteSheet(texture))
+			return;
+		
 		RetrieveSettings ();
 		TextureImporter textureImporter = (TextureImporter)assetImporter;
 		textureImporter.textureType = TextureImporterType.Sprite;


### PR DESCRIPTION
Changed preProcess to verify if the texture is a LPC asset. Otherwise, all textures will be forced to 100ppu.